### PR TITLE
fix: add max-width and adjust tab wrapper margins

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,7 @@ const Content: FC<{}> = ({ }) => {
       return {
         title: groupName,
         id: groupName,
-        content: <div style={{ marginLeft: "-10px", marginRight: "-10px" }}>
+        content: <div style={{ marginLeft: "-2.8vw", marginRight: "-2.8vw" }}>
           <PanelSection>
             {groupItem.map((paramData) => {
               return (
@@ -106,6 +106,7 @@ const Content: FC<{}> = ({ }) => {
           style={{
             height: "95%",
             width: "calc(100vw - 50px)",
+            maxWidth: "100%",
             marginTop: "-12px",
             position: "absolute",
             contain: "layout style paint",


### PR DESCRIPTION
fix: add max-width and adjust tab wrapper margins

Fix layout issues caused by recent Steam Client Beta updates.

- Change tab wrapper margin from `-10px` to `-2.8vw` to match viewport-based tab padding
- Add `maxWidth: "100%"` to prevent layout overflow

Reference: https://github.com/mengmeet/PowerControl/pull/109